### PR TITLE
restore the stripe api keys for local dev

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,8 +2,8 @@ var LOCAL_CONFIG = {
   appName: 'local',
   appVersion: '1',
   hardCodeStripe: true,
-  stripePublicKey: '',
-  stripePrivateKey: '',
+  stripePublicKey: 'pk_test_QNMKNczLGEwgOr0TmpjOCxmO',
+  stripePrivateKey: 'sk_test_lBGyF7m5cCVilat5siOlAIT6',
   productionPaypal: false,
 };
 


### PR DESCRIPTION
any objections to restoring the stripe test api keys to the repo? may unblock some devs during onboarding. according to aaron they were included, but recently removed.
