### PR TITLE
Only generate states totals every 10m

### DIFF
--- a/backend/handlers.py
+++ b/backend/handlers.py
@@ -7,7 +7,8 @@ import logging
 import cgi
 import base64
 import urllib
-import datetime
+import time
+import calendar
 
 from google.appengine.api import mail
 from google.appengine.ext import db
@@ -744,19 +745,29 @@ class ThankTeamHandler(webapp2.RequestHandler):
 # "... raising at least $5,000 in each of 20 states. Only contributions from
 # individuals, and only contributions up to $250, are matchable"
 class StatesHandler(webapp2.RequestHandler):
+  VALUE_KEY = "STATES-TOTALS"
+  TIME_KEY = "STATES-TIME"
   def get(self):
     util.EnableCors(self)
-    totals = {}
-    for pledge in model.Pledge.all():
-      user = model.User.all().filter('email =', pledge.email).get()
-      totals.setdefault(user.state, 0)
-      totals[user.state] += min(pledge.amountCents, 25000) # max $250
-
-    for state, total in totals.iteritems():
-      totals[state] = min(500000, total) # no point counting past $5k
     self.response.content_type = 'application/json'
-    self.response.write(json.dumps(totals))
-
+    now = calendar.timegm(time.gmtime())
+    then = memcache.get(StatesHandler.TIME_KEY)
+    old = memcache.get(StatesHandler.VALUE_KEY)
+    if old and ((now - then) < (10 * 60)):
+      self.response.write(old)
+    else:
+      logging.info('Recomputing states totals.')
+      memcache.set(StatesHandler.TIME_KEY, now)
+      totals = {}
+      for pledge in model.Pledge.all():
+        user = model.User.all().filter('email =', pledge.email).get()
+        totals.setdefault(user.state, 0)
+        totals[user.state] += min(pledge.amountCents, 25000) # max $250
+      for state, total in totals.iteritems():
+        totals[state] = min(500000, total) # no point counting past $5k
+      value = json.dumps(totals);
+      self.response.write(value)
+      memcache.set(StatesHandler.VALUE_KEY, value)
 
 class PledgersHandler(webapp2.RequestHandler):
 


### PR DESCRIPTION
Here's a quick and dirty patch to address the performance concern. It has the downside that it blocks the unlucky user who first requests expired data, but the upside that no work gets done if nobody wants the data. 
