### PR TITLE
Addition of kissmetrics analytics tracking script

### DIFF
--- a/markup/donate.jade
+++ b/markup/donate.jade
@@ -986,7 +986,7 @@ html(xmlns='https://www.w3.org/1999/xhtml', lang='en-US')
                                 button#pledgeButton.pledgeText.disabled(type='submit') Donate now
                               .other-ways
                                 a#paypalButton(href='#') PayPal
-                                |  or 
+                                |  or
                                 a.do-open-checkpop(href='#') donate by check
                                 a(href='/cdn-cgi/l/email-protection#6f060109002f030a1c1c060809001d1f1d0a1c060b0a011b410c0002501c1a0d050a0c1b52210a0a0b4a5d5f070a031f4a5d5f1f0e16060108') Need help?
                               .explain
@@ -1003,7 +1003,7 @@ html(xmlns='https://www.w3.org/1999/xhtml', lang='en-US')
                                 br
                                 | 								4. I do not hold a federal government contract.
                                 br
-                                | 								5. I am at least 18 years old. 
+                                | 								5. I am at least 18 years old.
                                 br
                                 | 								6. This contribution is not made from the funds of a political action committee.
                                 br
@@ -1344,3 +1344,8 @@ html(xmlns='https://www.w3.org/1999/xhtml', lang='en-US')
     ],
     "url": "https://lessig2016.us"
     }
+  <!-- Kissmetrics tracking snippet -->
+  script(type='text/javascript').
+    /* <![CDATA[ */
+    var _kmq = _kmq || [];var _kmk = _kmk || '4f23210cd28379cf965ea2351de1550b13999b93';function _kms(u){setTimeout(function(){var d = document, f = d.getElementsByTagName('script')[0],s = d.createElement('script');s.type = 'text/javascript'; s.async = true; s.src = u;f.parentNode.insertBefore(s, f);}, 1);}_kms('//i.kissmetrics.com/i.js');_kms('//scripts.kissmetrics.com/' + _kmk + '.2.js');
+    /* ]]> */


### PR DESCRIPTION
This adds the kissmetrics analytics script to the donate.jade file. Not sure if this needs to be added to any of the other pages. I was going to add this to ./includes/footer.jade but I don't see any references to this include in any of the root level <page>.jade files.
